### PR TITLE
fix: disable Nuxt UI remote fonts provider for reliable builds

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,3 @@
-import tailwindcss from "@tailwindcss/vite";
-
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   app: {
@@ -23,6 +21,9 @@ export default defineNuxtConfig({
     'nuxt-tiptap-editor',
     'shadcn-nuxt',
   ],
+  ui: {
+    fonts: false,
+  },
   runtimeConfig: {
     public: {
       baseUrl: process.env.BASE_URL || 'http://localhost:5000',
@@ -46,9 +47,4 @@ export default defineNuxtConfig({
      */
     componentDir: './components/ui'
   }
-  // vite: {
-  //   plugins: [
-  //     tailwindcss(),
-  //   ],
-  // },
 });


### PR DESCRIPTION
### Motivation
- Builds were intermittently failing or producing noisy errors from `@nuxt/fonts` when remote font metadata endpoints were unavailable, making CI/offline builds non-deterministic.

### Description
- Disabled Nuxt UI automatic font provider by adding `ui: { fonts: false }` to `nuxt.config.ts` and removed the unused `@tailwindcss/vite` import and commented `vite` block to keep the config clean.

### Testing
- Ran `pnpm build` which completed successfully and no longer emitted repeated remote-font provider initialization errors; test passed.
- Ran `pnpm exec nuxi typecheck` which failed due to an external `npm` registry `403` when fetching `vue-tsc`, so typecheck could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9705fb8883308e38b668b9e08f8d)