### PR TITLE
Fix auth resolution flow and analytics/data consistency issues

### DIFF
--- a/components/clients/columns.ts
+++ b/components/clients/columns.ts
@@ -43,7 +43,7 @@ export const columns: ColumnDef<Client>[] = [
         ? getExcerpt(description)
         : '';
 
-      return h('div', { class: 'text-left font-medium]' }, excerpt)
+      return h('div', { class: 'text-left font-medium' }, excerpt)
     },
   },
   {
@@ -55,7 +55,7 @@ export const columns: ColumnDef<Client>[] = [
         ? getExcerpt(contacts)
         : '';
 
-      return h('div', { class: 'text-left font-medium]' }, excerpt)
+      return h('div', { class: 'text-left font-medium' }, excerpt)
     },
   },
 ]

--- a/components/tasks/columns.ts
+++ b/components/tasks/columns.ts
@@ -43,7 +43,7 @@ export const columns: ColumnDef<Task>[] = [
         ? getExcerpt(description)
         : '';
 
-      return h('div', { class: 'text-left font-medium]' }, excerpt)
+      return h('div', { class: 'text-left font-medium' }, excerpt)
     },
   },
   {

--- a/composables/useAnalytics.ts
+++ b/composables/useAnalytics.ts
@@ -18,7 +18,7 @@ export const labelsMonths = [
   'Dec',
 ];
 
-export const getTasksOfTheYear = async (year: number) => {
+export const getTasksOfTheYear = async (year: number, uid: string) => {
   const db = (useNuxtApp().$firestore as Firestore);
 
   if (!db) {
@@ -31,6 +31,7 @@ export const getTasksOfTheYear = async (year: number) => {
 
   const tasksQuery = query(
     collection(db, "tasks"),
+    where("users", "array-contains", uid),
     where("start", ">=", startOfYear),
     where("start", "<=", endOfYear)
   );

--- a/composables/useFirebaseAuth.ts
+++ b/composables/useFirebaseAuth.ts
@@ -1,58 +1,43 @@
-import { GithubAuthProvider, signInWithPopup, signOut, type Auth, type User } from 'firebase/auth'
-import { useNuxtApp, onNuxtReady } from '#app'
-import { useAuthStore } from '~/stores/auth'
+import { GithubAuthProvider, signInWithPopup, signOut, type Auth, type User } from 'firebase/auth';
+import { useNuxtApp } from '#app';
+import { useAuthStore } from '~/stores/auth';
 
 export const useFirebaseAuth = () => {
-  const { $auth } = useNuxtApp()
-  let authStore: any = null
-
-  onNuxtReady(() => {
-    authStore = useAuthStore()
-  })
+  const { $auth } = useNuxtApp();
+  const authStore = useAuthStore();
 
   const signInWithGitHub = async (): Promise<User | null> => {
-    if (!authStore) {
-      console.warn('Pinia store is not ready yet. Waiting...')
-      await new Promise(resolve => setTimeout(resolve, 100))
-      authStore = useAuthStore()
-    }
-
     try {
-      const provider = new GithubAuthProvider()
-      const result = await signInWithPopup($auth as Auth, provider)
-      if (authStore) {
-        authStore.setUser(result.user)
-      }
-      return result.user
+      const provider = new GithubAuthProvider();
+      const result = await signInWithPopup($auth as Auth, provider);
+      authStore.setUser(result.user);
+      authStore.setAuthResolved(true);
+
+      return result.user;
     } catch (error) {
-      console.error('GitHub sign-in error:', error)
+      console.error('GitHub sign-in error:', error);
       throw error;
     }
-  }
+  };
 
   const signOutUser = async () => {
-    if (!authStore) {
-      authStore = useAuthStore()
-    }
-
     try {
-      await signOut($auth as Auth)
-      if (authStore) {
-        authStore.clearUser()
-      }
+      await signOut($auth as Auth);
+      authStore.clearUser();
+      authStore.setAuthResolved(true);
     } catch (error) {
-      console.error('Sign out error:', error)
+      console.error('Sign out error:', error);
       throw error;
     }
-  }
+  };
 
   const getCurrentUser = (): User | null => {
-    return ($auth as Auth)?.currentUser || null
-  }
+    return ($auth as Auth)?.currentUser || null;
+  };
 
   return {
     signInWithGitHub,
     signOutUser,
-    getCurrentUser
-  }
-}
+    getCurrentUser,
+  };
+};

--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,12 +1,26 @@
-export default defineNuxtRouteMiddleware(async (to, from) => { 
-  const authStore = useAuthStore()
-  const user = authStore.user
+export default defineNuxtRouteMiddleware(async (to) => {
+  const authStore = useAuthStore();
 
   if (to.path === '/login') {
-    return
+    return;
   }
 
-  if (!user) {
-    return navigateTo('/login')
+  if (!authStore.isAuthResolved) {
+    await new Promise<void>((resolve) => {
+      const stop = watch(
+        () => authStore.isAuthResolved,
+        (isResolved) => {
+          if (isResolved) {
+            stop();
+            resolve();
+          }
+        },
+        { immediate: true }
+      );
+    });
+  }
+
+  if (!authStore.user) {
+    return navigateTo('/login');
   }
 });

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -87,12 +87,21 @@ useAsyncData(
 );
 
 async function loadTasksOfYear(year: number) {
+  const uid = user.value?.uid;
+
+  if (!uid) {
+    thisYearTasks.value = [];
+    lastPeriodTasks.value = [];
+    return;
+  }
+
   const today = new Date();
   const currentMonth = today.getMonth();
-  const thisYear = await getTasksOfTheYear(year);
-  const lastYear = (tasksStore.tasks.values.length)
+  const thisYear = await getTasksOfTheYear(year, uid);
+  const lastYear = tasksStore.tasks.length
     ? dataTasksOfMonths(tasksStore.tasks, 1, currentMonth + 1)
-    : await getTasksOfTheYear(year - 1)
+    : await getTasksOfTheYear(year - 1, uid);
+
   thisYearTasks.value = thisYear;
   lastPeriodTasks.value = lastYear;
 }

--- a/plugins/auth-state.client.ts
+++ b/plugins/auth-state.client.ts
@@ -1,0 +1,9 @@
+import type { Auth } from 'firebase/auth';
+import { useAuthStore } from '~/stores/auth';
+
+export default defineNuxtPlugin(() => {
+  const { $auth } = useNuxtApp();
+  const authStore = useAuthStore();
+
+  authStore.initializeAuth($auth as Auth);
+});

--- a/shared/utils/validators.ts
+++ b/shared/utils/validators.ts
@@ -30,5 +30,5 @@ export const editClientFormSchema = addClientFormSchema;
 
 export type AddClientFormData = z.infer<typeof addClientFormSchema>;
 export type AddClientFormErrors = Partial<Record<keyof AddClientFormData, string>>;
-export type EditClientFormData = z.infer<typeof editTaskFormSchema>;
-export type EditClientFormErrors = Partial<Record<keyof EditTaskFormData, string>>;
+export type EditClientFormData = z.infer<typeof editClientFormSchema>;
+export type EditClientFormErrors = Partial<Record<keyof EditClientFormData, string>>;

--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -1,16 +1,55 @@
-import { type User } from "firebase/auth";
+import { onAuthStateChanged, type Auth, type User } from "firebase/auth";
 import { defineStore } from 'pinia';
+
+export type AuthUser = {
+  uid: string;
+  email: string | null;
+  displayName: string | null;
+  photoURL: string | null;
+};
+
+const mapFirebaseUser = (user: User): AuthUser => ({
+  uid: user.uid,
+  email: user.email,
+  displayName: user.displayName,
+  photoURL: user.photoURL,
+});
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    user: null as User | null
+    user: null as AuthUser | null,
+    isAuthResolved: false,
+    _authInitialized: false,
   }),
   actions: {
-    setUser(user: User) {
-      this.user = user
+    setUser(user: User | AuthUser) {
+      this.user = 'uid' in user && 'emailVerified' in user
+        ? mapFirebaseUser(user)
+        : user;
     },
     clearUser() {
       this.user = null
+    },
+    setAuthResolved(value: boolean) {
+      this.isAuthResolved = value;
+    },
+    initializeAuth(auth: Auth) {
+      if (this._authInitialized) {
+        return;
+      }
+
+      this._authInitialized = true;
+      this.setAuthResolved(false);
+
+      onAuthStateChanged(auth, (firebaseUser) => {
+        if (firebaseUser) {
+          this.setUser(firebaseUser);
+        } else {
+          this.clearUser();
+        }
+
+        this.setAuthResolved(true);
+      });
     },
     getUserName(): string {
       return this.user?.displayName || this.user?.email || ''
@@ -19,5 +58,7 @@ export const useAuthStore = defineStore('auth', {
       return !!this.user
     }
   },
-  persist: true,
+  persist: {
+    pick: ['user'],
+  },
 });

--- a/stores/clients.ts
+++ b/stores/clients.ts
@@ -37,7 +37,6 @@ export const useClientsStore = defineStore('clientsStore', {
         await setDoc(clientsRef, client);
         // console.log('Client was created');
         await this.fetchUserClients(client.users[0]);
-        this.clients.push(client);
       } catch (error) {
         console.error('Error adding client:', error);
         throw error;

--- a/stores/tasks.ts
+++ b/stores/tasks.ts
@@ -36,7 +36,6 @@ export const useTasksStore = defineStore('tasksStore', {
         await setDoc(tasksRef, task);
         // console.log('Task was created');
         await this.fetchUserTasks(task.users[0]);
-        this.tasks.push(task);
       } catch (error) {
         console.error('Error adding task:', error);
         throw error;


### PR DESCRIPTION
### Motivation
- Prevent incorrect redirects and stale/unsafe persistence by replacing full Firebase `User` persistence with a minimal, serializable auth snapshot and explicit auth hydration. 
- Eliminate cross-user data leakage in analytics by scoping queries to the current user. 
- Fix data-consistency bugs (incorrect previous-period logic and duplicate local inserts after create) and small UX/typing issues discovered during the Nuxt audit. 

### Description
- Reworked auth handling: `stores/auth.ts` now stores a serializable `AuthUser` (`uid`, `email`, `displayName`, `photoURL`), exposes `isAuthResolved`, uses `onAuthStateChanged` for hydration and limits persistence to `user` via `persist.pick`. 
- Added a client plugin `plugins/auth-state.client.ts` to initialize auth on app start and updated `middleware/auth.global.ts` to wait for `isAuthResolved` before redirecting. 
- Simplified `composables/useFirebaseAuth.ts` to use the store synchronously and to set `isAuthResolved` on sign-in/sign-out. 
- Hardened analytics and page logic: `composables/useAnalytics.ts` new `getTasksOfTheYear(year, uid)` filters by `where('users', 'array-contains', uid)` and `pages/index.vue` now passes `uid`, checks `tasks.length` (replacing `tasks.values.length`) and guards for missing `uid`. 
- Data consistency and types: removed duplicate `this.tasks.push(...)`/`this.clients.push(...)` after refetch in `stores/tasks.ts` and `stores/clients.ts`, and fixed client form types in `shared/utils/validators.ts` to derive from `editClientFormSchema`. 
- Minor UI fixes: corrected `font-medium]` → `font-medium` typos in `components/tasks/columns.ts` and `components/clients/columns.ts`. 

### Testing
- Performed a full production build with `pnpm build`, which completed successfully (build warnings from third-party libs such as `vue3-charts` and large chunk sizes remain and are tracked separately). 
- Started the dev server and captured a headless browser screenshot of the login page to validate UI and auth flow startup. 
- No automated unit tests were added in this change set; build and smoke validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9c5662b08330b86aaa1a631562e3)